### PR TITLE
Ensure that generated BNF grammar is compiled by babel.

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -16,5 +16,5 @@ mkdir -p dist/plugins/ruby/templates
 cp -r src/plugins/ruby/templates/* dist/plugins/ruby/templates/
 
 mkdir dist/generated
-cp -r src/generated/* dist/generated/
+node_modules/.bin/babel src/generated/bnf-parser.gen -o dist/generated/bnf-parser.gen --presets es2015,stage-1,stage-2
 babel src/ --out-dir dist/ --presets es2015,stage-1,stage-2 --ignore templates/


### PR DESCRIPTION
`src/generated/bnf-parser.gen` contains ES6 syntax which causes `bin/syntax` to choke when run from standard node.