### PR TITLE
PHP Plugin: Start Conditions and Minor Fixes

### DIFF
--- a/src/plugins/php/templates/ll.template.php
+++ b/src/plugins/php/templates/ll.template.php
@@ -64,7 +64,7 @@ class yyparse {
     $tokenizer = self::getTokenizer();
 
     if (!$tokenizer) {
-      throw new Exception(`Tokenizer instance wasn't specified.`);
+      throw new \Exception(`Tokenizer instance wasn't specified.`);
     }
 
     $tokenizer->initString($string);
@@ -125,11 +125,10 @@ class yyparse {
   }
 
   private static function parseError($message) {
-    throw new Exception('Parse error: '.$message);
+    throw new \Exception('Parse error: '.$message);
   }
 }
 
 <<TOKENIZER>>
 
 class <<PARSER_CLASS_NAME>> extends yyparse {}
-

--- a/src/plugins/php/templates/lr.template.php
+++ b/src/plugins/php/templates/lr.template.php
@@ -64,7 +64,7 @@ class yyparse {
     $tokenizer = self::getTokenizer();
 
     if (!$tokenizer) {
-      throw new Exception(`Tokenizer instance wasn't specified.`);
+      throw new \Exception(`Tokenizer instance wasn't specified.`);
     }
 
     $tokenizer->initString($string);
@@ -170,7 +170,7 @@ class yyparse {
   }
 
   private static function parseError($message) {
-    throw new Exception('Parse error: '.$message);
+    throw new \Exception('Parse error: '.$message);
   }
 }
 

--- a/src/plugins/php/templates/lr.template.php
+++ b/src/plugins/php/templates/lr.template.php
@@ -104,7 +104,7 @@ class yyparse {
         $pn = intval(substr($e, 1));
         $p = $ps[$pn];
         $hsa = count($p) > 2;
-        $saa = hsa ? [] : null;
+        $saa = $hsa ? [] : null;
 
         if ($p[1] !== 0) {
           $rhsl = $p[1];
@@ -177,4 +177,3 @@ class yyparse {
 <<TOKENIZER>>
 
 class <<PARSER_CLASS_NAME>> extends yyparse {}
-

--- a/src/plugins/php/templates/tokenizer.template.php
+++ b/src/plugins/php/templates/tokenizer.template.php
@@ -52,7 +52,7 @@ class __SyntaxToolTokenizer {
       }
     }
 
-    throw new Exception('Unexpected token: ' . $string[0]);
+    throw new \Exception('Unexpected token: ' . $string[0]);
   }
 
   public function isEOF() {

--- a/src/plugins/php/templates/tokenizer.template.php
+++ b/src/plugins/php/templates/tokenizer.template.php
@@ -9,7 +9,9 @@
 
 class __SyntaxToolTokenizer {
   private static $lexRules = <<LEX_RULES>>;
+  private static $lexRulesByConditions = <<LEX_RULES_BY_START_CONDITIONS>>;
 
+  private $states = array();
   private $string = '';
   private $cursor = 0;
 
@@ -21,8 +23,32 @@ class __SyntaxToolTokenizer {
   <<LEX_RULE_HANDLERS>>
 
   public function initString($string) {
+    $this->states = array('INITIAL');
     $this->string = $string.yyparse::EOF;
     $this->cursor = 0;
+  }
+
+  public function getStates() {
+    return $this->states;
+  }
+
+  public function getCurrentState() {
+    return $this->states[count($this->states) - 1];
+  }
+
+  public function pushState($state) {
+    $this->states[] = $state;
+  }
+
+  public function begin($state) {
+    $this->pushState(state);
+  }
+
+  public function popState() {
+    if (count($this->states) > 1) {
+      return array_pop($this->states);
+    }
+    return $this->states[0];
   }
 
   public function getNextToken() {
@@ -34,13 +60,16 @@ class __SyntaxToolTokenizer {
     }
 
     $string = substr($this->string, $this->cursor);
+    $lexRulesForState = static::$lexRulesByConditions[$this->getCurrentState()];
 
-    foreach (self::$lexRules as $lex_rule) {
+    foreach ($lexRulesForState as $lex_rule_index) {
+      $lex_rule = self::$lexRules[$lex_rule_index];
+
       $matched = $this->match($string, $lex_rule[0]);
       if ($matched) {
         yyparse::$yytext = $matched;
         yyparse::$yyleng = strlen($matched);
-        $token = forward_static_call(array('self', $lex_rule[1]));
+        $token = call_user_func(array($this, $lex_rule[1]));
         if (!$token) {
           return $this->getNextToken();
         }


### PR DESCRIPTION
The root namespace on the Exception classes instantiation allows the user to specify a namespace in the "moduleInclude".

To make the syntax similar to the Javascript version when pushing a state, the handlers were modified to be methods of the class instead of static functions.