### PR TITLE
Use SPDX-style license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "C#"
   ],
   "author": "Dmitry Soshnikov",
-  "license": "MIT Style License",
+  "license": "MIT",
   "dependencies": {
     "babel-cli": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
Hi! This looks like a cool project :-)

This is the most useless PR, I do apologise; it simply changes the license field in your `package.json` to be "MIT".
Apparently this is a thing; otherwise I see

> warning syntax-cli@0.0.78: License should be a valid SPDX license expression

If this bugs you, feel free to ignore. 
Cheers!