### PR TITLE
Fix a typo in JS code. Remove has_key from generated Python code

### DIFF
--- a/src/lr/lr-parsing-table.js
+++ b/src/lr/lr-parsing-table.js
@@ -373,7 +373,7 @@ export default class LRParsingTable {
         symbolConflictData.resolved = 'shift (same precedence, right-assoc)';
       } else if (symbolAssoc === 'nonassoc') {
         // No action on `nonassoc`.
-        delete rows[symbol];
+        delete row[symbol];
         symbolConflictData.resolved = 'removed conflict for nonassoc';
       }
     }

--- a/src/plugins/python/templates/lr.template.py
+++ b/src/plugins/python/templates/lr.template.py
@@ -178,7 +178,7 @@ def parse(string):
             if len(stack) != 1 or stack[0] != 0 or _tokenizer.has_more_tokens():
                 _unexpected_token(token)
 
-            if parsed.has_key('semantic_value'):
+            if 'semantic_value' in parsed.has_key:
                 on_parse_end(parsed['semantic_value'])
                 return parsed['semantic_value']
 


### PR DESCRIPTION
`rows` in JS code was apparently a typo.

Using `in` instead of `has_key` in generated Python code makes it Python 3.x compatible.