### PR TITLE
Implement LALR-by-SLR algorithm

### DIFF
--- a/src/bin/syntax.js
+++ b/src/bin/syntax.js
@@ -322,6 +322,10 @@ const parsers = {
     return this._genericLR(GRAMMAR_MODE.LALR1, options);
   },
 
+  LALR1_BY_SLR1() {
+    return this._genericLR(GRAMMAR_MODE.LALR1_BY_SLR1, options);
+  },
+
   _genericLR(mode, options) {
     const grammar = getGrammar(options.grammar, mode);
 

--- a/src/grammar/grammar-mode.js
+++ b/src/grammar/grammar-mode.js
@@ -7,6 +7,8 @@ export const MODES = {
   LR0: 'LR0',
   SLR1: 'SLR1',
   LALR1: 'LALR1',
+  LALR1_BY_SLR1: 'LALR1_BY_SLR1',
+  LALR1_EXTENDED: 'LALR1_EXTENDED',
   CLR1: 'CLR1',
   LL1: 'LL1',
 };
@@ -55,6 +57,16 @@ export default class GrammarMode {
 
   isLALR1() {
     return this._isMode(MODES.LALR1);
+  }
+
+  isLALR1BySLR1() {
+    return this._isMode(MODES.LALR1_BY_SLR1);
+  }
+
+  isLALR1Extended() {
+    // Special grammar mode, where productions are built from
+    // the LR(0) automation in the "LALR(1) by SLR(1)" algorithm.
+    return this._isMode(MODES.LALR1_EXTENDED);
   }
 
   isCLR1() {

--- a/src/grammar/grammar-symbol.js
+++ b/src/grammar/grammar-symbol.js
@@ -35,6 +35,38 @@ export default class GrammarSymbol {
   }
 
   /**
+   * Returns original symbol from an extended name. 1X3 => X
+   */
+  getOrignialSymbol() {
+    if (!this._originalSymbol) {
+      this._originalSymbol = this._symbol
+        .replace(/^\d+\|/, '')
+        .replace(/\|(?:\d+|\$)$/, '');
+    }
+    return this._originalSymbol;
+  }
+
+  /**
+   * Returns start context (in extended LALR 1X3 => 1)
+   */
+  getStartContext() {
+    if (!this._startContext) {
+      this._startContext = Number(this._symbol.match(/^(\d+)\|/)[1]);
+    }
+    return this._startContext;
+  }
+
+  /**
+   * Returns start context (in extended LALR 1X3 => 1)
+   */
+  getEndContext() {
+    if (!this._endContext) {
+      this._endContext = Number(this._symbol.match(/\|(\d+)$/)[1]);
+    }
+    return this._endContext;
+  }
+
+  /**
    * Returns a symbol from the registry, or creates one.
    */
   static get(symbol) {
@@ -91,7 +123,7 @@ export default class GrammarSymbol {
    * Checks whether a symbol is Epsilon (static method).
    */
   static isEpsilon(symbol) {
-    return symbol === EPSILON;
+    return symbol.includes(EPSILON);
   }
 
   /**

--- a/src/grammar/grammar.js
+++ b/src/grammar/grammar.js
@@ -609,15 +609,18 @@ export default class Grammar {
     let processedBnf = [];
     let nonTerminals = Object.keys(originalBnf);
 
+    const isDefaultLR = this._mode.isLR() && !this._mode.isLALR1Extended();
+
     // LR grammar uses augmented 0-production.
-    let number = this._mode.isLR() ? 0 : 1;
+    let number = isDefaultLR ? 0 : 1;
 
     if (!this._startSymbol) {
       this._startSymbol = nonTerminals[0];
     }
 
-    if (this._mode.isLR()) {
-      // Augmented rule, $accept -> S.
+    // Augmented rule, $accept -> S. The LALR(1) extended
+    // grammar already have this rule.
+    if (isDefaultLR) {
       let augmentedProduction = new Production(
         /* LHS */ '$accept',
         /* RHS */ this._startSymbol,

--- a/src/lr/canonical-collection.js
+++ b/src/lr/canonical-collection.js
@@ -4,8 +4,10 @@
  */
 
 import Grammar from '../grammar/grammar';
+import {MODES as GRAMMAR_MODES} from '../grammar/grammar-mode';
 import LRItem from './lr-item';
 import SetsGenerator from '../sets-generator';
+import {EOF, EPSILON} from '../special-symbols';
 
 import debug from '../debug';
 
@@ -47,7 +49,7 @@ export default class CanonicalCollection {
       /* canonicalCollection */ this,
       /* setsGenerator */ new SetsGenerator({grammar}),
       /*lookaheadSet */ this._grammar.getMode().usesLookaheadSet()
-        ? {'$': true}
+        ? {[EOF]: true}
         : null,
     );
 
@@ -61,21 +63,31 @@ export default class CanonicalCollection {
     debug.timeEnd('Building canonical collection');
     debug.log(`Number of states in the collection: ${this._states.size}`);
 
-    if (this._grammar.getMode().isLALR1()) {
+
+    // LALR(1) by converting to SLR(1): fast, but less precise,
+    // can merge epsilon rules.
+    if (this._grammar.getMode().isLALR1BySLR1()) {
+      this._buildLALRBySLR();
+    }
+
+    // LALR(1) by compressing CLR(1): slow, but more precise,
+    // works well with epsilon-rules.
+    else if (this._grammar.getMode().isLALR1()) {
       debug.time('Compressing CLR to LALR');
-      this.compressCLRToLALR();
+      this._compressCLRToLALR();
       debug.timeEnd('Compressing CLR to LALR');
       debug.log(`Number of states after compression: ${this._states.size}`);
     }
+
   }
 
   /**
    * Basic LALR(1) implementation compressing from CLR(1).
    *
-   * TODO: implement more efficient algorithm, e.g.
-   * LALR(1) by converting to SLR(1).
+   * This can be slow on complex grammars, and one can better
+   * use LALR(1) by SLR(1) method.
    */
-  compressCLRToLALR() {
+  _compressCLRToLALR() {
     for (let lr0StateKey in this._lr0ItemSets) {
       const states = this._lr0ItemSets[lr0StateKey];
 
@@ -103,6 +115,174 @@ export default class CanonicalCollection {
 
     // After compression reassign new numbers to states.
     this._remap();
+  }
+
+  /**
+   * Builds LALR(1) by SLR(1) grammar, and post-processes LR-items
+   * by calculating needed lookahead sets.
+   *
+   * See good concise explanation of the algorithm here:
+   * https://web.cs.dal.ca/~sjackson/lalr1.html
+   */
+  _buildLALRBySLR() {
+    debug.time('Building LALR-by-SLR');
+    this._buildExtendedLALR1Grammar();
+
+    this._extendedFollowSets =
+      (new SetsGenerator({grammar: this._extendedLALRGrammar}))
+        .getFollowSets();
+
+    // Mutate the set with extended symbols to reflect the
+    // symbols from the original grammar.
+    for (const nonTerminal in this._extendedFollowSets) {
+      const set = this._extendedFollowSets[nonTerminal];
+      for (const symbol in set) {
+        if (this._setsAliasMap.hasOwnProperty(symbol)) {
+          set[this._setsAliasMap[symbol]] = true;
+          delete set[symbol];
+        }
+      }
+    }
+
+    this._groupExtendedLALRByFinalSets();
+    this._updateLALRItemReduceSet();
+    debug.timeEnd('Building LALR-by-SLR');
+  }
+
+  /**
+   * Groups extended LALR(1) by final sets.
+   *
+   * We merge extended rules, if they are from the same original
+   * rule, and go to the same final set (has the same state number
+   * in the very last symbol of RHS).
+   */
+  _groupExtendedLALRByFinalSets() {
+    debug.time('LALR-by-SLR: Group extended productions by final sets');
+    this._groupedFinalSets = {};
+
+    this._extendedLALRGrammar.getProductions().forEach(production => {
+      const LHS = production.getLHS();
+      const RHS = production.getRHS();
+      const lastSymbol = RHS[RHS.length - 1];
+      const originalLHS = LHS.getOrignialSymbol();
+      const finalSet = lastSymbol.getEndContext();
+
+      if (!this._groupedFinalSets.hasOwnProperty(finalSet)) {
+        this._groupedFinalSets[finalSet] = {};
+      }
+
+      if (!this._groupedFinalSets[finalSet].hasOwnProperty(originalLHS)) {
+        this._groupedFinalSets[finalSet][originalLHS] = {};
+      }
+
+      // Merge follow sets.
+      Object.assign(
+        this._groupedFinalSets[finalSet][originalLHS],
+        this._extendedFollowSets[LHS.getSymbol()]
+      );
+    });
+
+    debug.timeEnd('LALR-by-SLR: Group extended productions by final sets');
+  }
+
+  /**
+   * Updates the reduce sets for items in the LALR by SLR algorithm.
+   */
+  _updateLALRItemReduceSet() {
+    debug.time('LALR-by-SLR: Updating item reduce sets');
+    const states = [...this._states];
+    for (const state in this._groupedFinalSets) {
+      states[state].getReduceItems().forEach(reduceItem => {
+        const LHS = reduceItem.getProduction().getLHS().getSymbol();
+        reduceItem.setReduceSet(this._groupedFinalSets[state][LHS]);
+      });
+    }
+    debug.timeEnd('LALR-by-SLR: Updating item reduce sets');
+  }
+
+  /**
+   * We use LALR(1) by SLR(1) algorithm here. Once we have built LR(0)
+   * automation, we build the extended grammar, considering the context.
+   * This context further results to needed lookahead set for LALR(1) which
+   * is obtain as Follow(LHS), i.e. the same as in SLR(1).
+   */
+  _buildExtendedLALR1Grammar() {
+    debug.time('LALR-by-SLR: Building extended grammar for LALR');
+
+    const extendedBnf = {};
+    this._setsAliasMap = {};
+
+    for (const state of this._states) {
+      const items = state.getItems();
+      for (const item of items) {
+        // Extended items are built only for beginning items.
+        if (!item.isBeginning()) {
+          continue;
+        }
+        // We traverse the full path of the item, in order to
+        // to identify components with contexts.
+        let current = item;
+        const visited = new Set();
+
+        const LHS = item.getProduction().getLHS().getSymbol();
+
+        const lhsTransit = state.getTransitionOnSymbol(LHS);
+        const lhsToState = lhsTransit
+          ? lhsTransit.state.getNumber()
+          : '$';
+
+        const extendedLHSSymbol = `${state.getNumber()}|${LHS}|${lhsToState}`;
+
+        // Init the rules for the new LHS.
+        if (!extendedBnf.hasOwnProperty(extendedLHSSymbol)) {
+          extendedBnf[extendedLHSSymbol] = [];
+        }
+
+        const extendedRHS = [];
+
+        while (current !== null && !visited.has(current)) {
+          visited.add(visited);
+          const transitionSymbol = current.getCurrentSymbol();
+
+          if (transitionSymbol) {
+            const rawSymbol = transitionSymbol.getSymbol();
+            const fromState = current.getState().getNumber();
+            let toState;
+
+            // Epsilon reduces in this state.
+            if (transitionSymbol.isEpsilon()) {
+              toState = fromState;
+            } else if (current.getNext()) {
+              toState = current.getNext().getState().getNumber();
+            }
+
+            if (toState != null) {
+              const extendedRHSSymbol = `${fromState}|${rawSymbol}|${toState}`;
+              extendedRHS.push(extendedRHSSymbol);
+
+              // Collect extended token/terminal symbols as aliases of the
+              // original terminal symbols: this is needed to compute
+              // First/Follow sets as original symbols.
+              if (this._grammar.isTokenSymbol(rawSymbol)) {
+                this._setsAliasMap[extendedRHSSymbol] = rawSymbol;
+              }
+            }
+          }
+
+          current = current.getNext();
+        }
+
+        // Append the new RHS alternative.
+        extendedBnf[extendedLHSSymbol].push(extendedRHS.join(' '));
+      }
+    }
+
+    this._extendedLALRGrammar = new Grammar({
+      bnf: extendedBnf,
+      mode: GRAMMAR_MODES.LALR1_EXTENDED,
+    });
+
+    debug.timeEnd('LALR-by-SLR: Building extended grammar for LALR');
   }
 
   registerState(state) {
@@ -160,7 +340,7 @@ export default class CanonicalCollection {
   }
 
   print() {
-    console.log('\nCanonical collection of LR items:');
+    console.info('\nCanonical collection of LR items:');
     this._grammar.print();
 
     this._states.forEach(state => {
@@ -174,7 +354,7 @@ export default class CanonicalCollection {
         }
       }
 
-      console.log(
+      console.info(
         `\nState ${state.getNumber()}:` +
         (stateTags.length > 0 ? ` (${stateTags.join(', ')})` : '')
       );
@@ -210,7 +390,7 @@ export default class CanonicalCollection {
       itemTags.push(`goes to state ${item.goto().getNumber()}`);
     }
 
-    console.log(
+    console.info(
       `  - ${item.toString()}` +
       (itemTags.length > 0 ? ` (${itemTags.join(', ')})` : '')
     );

--- a/src/lr/state.js
+++ b/src/lr/state.js
@@ -106,7 +106,10 @@ export default class State {
    * Returns all reduce items in this set.
    */
   getReduceItems() {
-    return this._items.filter(item => item.isReduce());
+    if (!this._reduceItems) {
+      this._reduceItems = this._items.filter(item => item.isReduce());
+    }
+    return this._reduceItems;
   }
 
   /**


### PR DESCRIPTION
Fixes #52.

Experimental "LALR by SLR" algorithm, currently is under `lalr1_by_slr1` mode. Later it'll be the main `lalr1` mode, and previous (slow) will be moved to `lalr1_by_clr1`.

This improves performance of the LALR(1) parser generator.