### PR TITLE
Working on rust plugin:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2125,6 +2125,7 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -2133,6 +2134,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -2149,7 +2151,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -2166,12 +2169,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -2184,12 +2189,14 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -2235,7 +2242,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -2261,7 +2269,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -2432,6 +2441,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2445,7 +2455,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -2518,12 +2529,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -2597,7 +2610,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -2655,7 +2669,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2693,6 +2708,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -2744,7 +2760,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2802,6 +2819,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2812,6 +2830,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -2840,6 +2859,7 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -2895,7 +2915,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",

--- a/src/plugins/rust/templates/lr.template.rs
+++ b/src/plugins/rust/templates/lr.template.rs
@@ -271,19 +271,7 @@ impl Parser {
     }
 
     fn unexpected_token(&mut self, token: &Token) {
-        if token.value == EOF && !self.tokenizer.has_more_tokens() {
-            self.unexpected_end_of_input();
-        }
-
-        self.tokenizer.panic_unexpected_token(
-            token.value,
-            token.start_line,
-            token.start_column
-        );
-    }
-
-    fn unexpected_end_of_input(&mut self) {
-        panic!("\n\nUnexpected end of input.\n\n");
+        {{{ON_PARSE_ERROR_CALL}}}
     }
 
     {{{PRODUCTION_HANDLERS}}}


### PR DESCRIPTION
  In function 'get_next_token'(tokenizer.template.rs):
    1. Parse the regex only once instead of parsing it in the loop. This increased performance by about 10 times.
    2. Loop variable 'i' should iterate over lex_rules_for_state instead of 0..lex_rules_for_state.len().
    3. Find the longest match instead of return at once when finding a match.

  In function 'generateLexRules'(rust-parser-generator-trait.js):
    1. Add many '#' for rust's raw string literal, so that '"' can be understood correctly.
    2. Replace '\/' with '/'. The former one cause regex parser to panic! because there is no such escape sequence as '\/'.
    3. Add hook ON_PARSE_ERROR_CALL in lr.template.rs and deal with this hook here. This is for customized error handling.