### PR TITLE
Allow programmatic usage

### DIFF
--- a/src/base-parser-generator.js
+++ b/src/base-parser-generator.js
@@ -143,6 +143,9 @@ export default class BaseParserGenerator {
    */
   generate() {
     this.generateParserData();
+    if(!this._outputFile){
+      return this._resultData;
+    }
     fs.writeFileSync(this._outputFile, this._resultData, 'utf-8');
     debug.timeEnd('Generating parser module');
     try {


### PR DESCRIPTION
I want to generate the parser when I am building my code, not from command line.
So I wrote a webpack loader and a jest transform, but I need one change in the code.
If no output file if specified, I return the parser as a string (don't want to do file write and read for that case).
That's what I did in this PR.

For info, the associated code for the Jest transform:

```
const LRParserGenerator = require('syntax-cli/dist/lr/lr-parser-generator-default')
    .default;
const Grammar = require('syntax-cli/dist/grammar/grammar').default;
const GRAMMAR_MODE = require('syntax-cli/dist/grammar/grammar-mode').MODES;

module.exports = {
    process(source) {
        const parser = new LRParserGenerator({
            grammar: Grammar.fromData(Grammar.dataFromString(source, 'bnf'), {
                mode: GRAMMAR_MODE.LALR1_BY_SLR1,
            })
        }).generate();
        return parser;
    },
}; 
```
