### PR TITLE
Protect the program's `global` Object

### DIFF
--- a/src/code-unit.js
+++ b/src/code-unit.js
@@ -5,7 +5,7 @@
 
 import vm from 'vm';
 
-const SANDBOX = Object.assign(global, {
+const SANDBOX = Object.assign({},global, {
   /**
    * Matched text of the tokenizer.
    */


### PR DESCRIPTION
I assume the intent of the sandbox is _not_ to allow code inside the sandbox to pollute the program's `global` and allow modifications to it.

Compare existing:
```
A = Object.assign(global,{z:4})
global.z // 4
A.foo = 5
global.foo // 5
```
with
```
A = Object.assign({},global,{z:4})
global.z // undefined
A.foo = 5
global.foo // undefined
```