### PR TITLE
Fixed lexer for rust parser

### DIFF
--- a/src/plugins/rust/templates/lr.template.rs
+++ b/src/plugins/rust/templates/lr.template.rs
@@ -7,7 +7,7 @@ extern crate onig;
 #[macro_use]
 extern crate lazy_static;
 
-use onig::Regex;
+use onig::{Regex, Syntax, RegexOptions};
 use std::collections::HashMap;
 
 /**

--- a/src/plugins/rust/templates/tokenizer.template.rs
+++ b/src/plugins/rust/templates/tokenizer.template.rs
@@ -36,7 +36,7 @@ lazy_static! {
     /** 
      * Pre-parse the regex instead of parsing it every time when calling `get_next_token`.
      */
-    static ref REGEX_RULES: Vec<Regex> = LEX_RULES.iter().map(|rule| Regex::new(rule).unwrap()).collect();
+    static ref REGEX_RULES: Vec<Regex> = LEX_RULES.iter().map(|rule| Regex::with_options(rule, RegexOptions::REGEX_OPTION_SINGLELINE, Syntax::default()).unwrap()).collect();
 }
 
 struct Tokenizer<'t> {


### PR DESCRIPTION
How lexer works: it takes lex rules as regexps and tries match each with string, and it assumes each possible matching will be at begging of string being scanned:
for this it prepends `^` char for each regular expression. But, it doesn't work for multiline regepxs.

So, this commit switches regexps back to singleline mode for rust plugin.

It's regression bug introduced in #81, where I replaced regex::Regex with onig::Regex, which by default creates multiline regexps instead of regex::Regex module.