### PR TITLE
Fix --custom-tokenizer having no effect

### DIFF
--- a/src/base-parser-generator.js
+++ b/src/base-parser-generator.js
@@ -21,10 +21,9 @@ export default class BaseParserGenerator {
 
     this._grammar = grammar;
     this._outputFile = outputFile;
-    this._customTokenizer = customTokenizer;
+    this._customTokenizer = customTokenizer || options.customTokenizer;
     this._encodeSymbols();
     this._options = options;
-
     const templateTags = this.getTemplateTags();
     this._openTag = templateTags.open;
     this._closeTag = templateTags.close;

--- a/src/base-parser-generator.js
+++ b/src/base-parser-generator.js
@@ -24,6 +24,7 @@ export default class BaseParserGenerator {
     this._customTokenizer = customTokenizer || options.customTokenizer;
     this._encodeSymbols();
     this._options = options;
+
     const templateTags = this.getTemplateTags();
     this._openTag = templateTags.open;
     this._closeTag = templateTags.close;


### PR DESCRIPTION
The value supplied by the command line option "--custom-tokenizer" (-k) wasn't having an effect on the generated Javascript output. This pull request fixes that by having the constructor for BaseParserGenerator examine its "options" argument for a "customTokenizer" property when the "customTokenizer" argument is not supplied.