### PR TITLE
Removed export of parse function, base library conflict

### DIFF
--- a/src/plugins/julia/templates/lr.template.jl
+++ b/src/plugins/julia/templates/lr.template.jl
@@ -18,11 +18,6 @@ module SyntaxParser
 =#
 
 # --------------------------------------------------------------
-# Exports: The parse method, if concerned about disambiguating with other
-# parse methods in your use case, use 'import' instead of 'using'
-export parse
-
-# --------------------------------------------------------------
 # Shared includes
 using DataStructures
 


### PR DESCRIPTION
Have to remove export of 'parse' as this conflicts with Julia base libraries and causes errors when calling base parse methods that could impact various unrelated places in a user's code.