### PR TITLE
Warning about capture characters

### DIFF
--- a/src/bin/syntax.js
+++ b/src/bin/syntax.js
@@ -554,7 +554,7 @@ function getGrammar(grammarFile, mode) {
     return null;
   }
 
-  const grammarData = Grammar.dataFromGrammarFile(grammarFile, 'bnf');
+  const grammarData = Grammar.dataFromGrammarFile(grammarFile, 'bnf', options.loc);
 
   // If explicit lexical grammar file was passed, use it.
   const lexGrammarData = getLexGrammarData(options);

--- a/src/bin/syntax.js
+++ b/src/bin/syntax.js
@@ -554,7 +554,10 @@ function getGrammar(grammarFile, mode) {
     return null;
   }
 
-  const grammarData = Grammar.dataFromGrammarFile(grammarFile, 'bnf', options.loc);
+  const grammarData = Grammar.dataFromGrammarFile(grammarFile, {
+    grammarType: 'bnf',
+    useLocation: options.loc,
+  });
 
   // If explicit lexical grammar file was passed, use it.
   const lexGrammarData = getLexGrammarData(options);

--- a/src/bin/syntax.js
+++ b/src/bin/syntax.js
@@ -587,7 +587,7 @@ function getLexGrammarData(options) {
 
   // If explicit lexical grammar file was passed, use it.
   if (options.lex) {
-    data = Grammar.dataFromGrammarFile(options.lex, 'lex');
+    data = Grammar.dataFromGrammarFile(options.lex, { grammarType: 'lex' });
   }
 
   if (options['ignore-whitespaces'] && !data) {

--- a/src/grammar/grammar.js
+++ b/src/grammar/grammar.js
@@ -176,11 +176,33 @@ export default class Grammar {
    * Reads grammar file data. Supports reading `bnf`,
    * and `lex` grammars based on mode.
    */
-  static dataFromGrammarFile(grammarFile, grammarType = 'bnf') {
-    return Grammar.dataFromString(
-      fs.readFileSync(grammarFile, 'utf-8'),
-      grammarType
-    );
+  static dataFromGrammarFile(grammarFile, grammarType = 'bnf', loc = false) {
+    const grammar = fs.readFileSync(grammarFile, 'utf8');
+
+    // check if the bnf grammar contains location capture characters
+    if (grammarType === 'bnf' && !loc) {
+      const bnf = grammar
+        // lexer rules
+        .replace(/%lex[\n\s\S]*?\/lex/g, '')
+        // comments
+        .replace(/\/\*[\n\s\S]*?\*\//g, '')
+        .replace(/\/\/.*?\n/g, '')
+        //strings
+        .replace(/'(\\.|[^'\\])*'/g, '')
+        .replace(/"(\\.|[^"\\])*"/g, '')
+        .replace(/`(\\.|[^`\\])*`/g, '')
+        // module include
+        .replace(/%{[\n\s\S]*?%}/g, '');
+
+      if (bnf.includes('@')) {
+        console.info(colors.red(
+          'The grammar file contains location capture characters (@), which require the ' +
+          '"--loc" option, but it has not been provided. The generated parser will throw an error.'
+        ));
+      }
+    }
+
+    return Grammar.dataFromString(grammar, grammarType);
   }
 
   /**

--- a/src/grammar/grammar.js
+++ b/src/grammar/grammar.js
@@ -168,7 +168,7 @@ export default class Grammar {
    * for the specific options.
    */
   static fromGrammarFile(grammarFile, options = {}, grammarType = 'bnf') {
-    const grammarData = Grammar.dataFromGrammarFile(grammarFile, grammarType);
+    const grammarData = Grammar.dataFromGrammarFile(grammarFile, { grammarType });
     return Grammar.fromData(grammarData, options);
   }
 

--- a/src/grammar/grammar.js
+++ b/src/grammar/grammar.js
@@ -194,7 +194,7 @@ export default class Grammar {
         // module include
         .replace(/%{[\n\s\S]*?%}/g, '');
 
-      if (bnf.includes('@')) {
+      if (/@\w+/.test(bnf)) {
         console.info(colors.red(
           'The grammar file contains location capture characters (@), which require the ' +
           '"--loc" option, but it has not been provided. The generated parser will throw an error.'

--- a/src/grammar/grammar.js
+++ b/src/grammar/grammar.js
@@ -176,11 +176,11 @@ export default class Grammar {
    * Reads grammar file data. Supports reading `bnf`,
    * and `lex` grammars based on mode.
    */
-  static dataFromGrammarFile(grammarFile, grammarType = 'bnf', loc = false) {
+  static dataFromGrammarFile(grammarFile, { grammarType = 'bnf', useLocation = false }) {
     const grammar = fs.readFileSync(grammarFile, 'utf8');
 
     // check if the bnf grammar contains location capture characters
-    if (grammarType === 'bnf' && !loc) {
+    if (grammarType === 'bnf' && !useLocation) {
       const bnf = grammar
         // lexer rules
         .replace(/%lex[\n\s\S]*?\/lex/g, '')


### PR DESCRIPTION
If you capture locations in the bnf grammar file used to generate a parser, without using the --loc option, the parser will be successfully generated, but it will throw an error at runtime because the location variables are not defined.

This shows a warning when generating the parser if the grammar file contains location capture characters and the --loc option is not provided.