### PR TITLE
Remove semicolons generation in Python plugin

### DIFF
--- a/src/grammar/grammar.js
+++ b/src/grammar/grammar.js
@@ -592,7 +592,7 @@ export default class Grammar {
   _generateLexRulesDataForTerminals() {
     return this.getTerminals().map(terminal => [
       LexRule.matcherFromTerminal(terminal.getSymbol()), // matcher
-      `return ${terminal.quotedTerminal()};`, // token handler
+      `return ${terminal.quotedTerminal()}`, // token handler
     ]);
   }
 

--- a/src/plugins/python/py-parser-generator-trait.js
+++ b/src/plugins/python/py-parser-generator-trait.js
@@ -51,7 +51,7 @@ const PythonParserGeneratorTrait = {
    */
   createLocationPrologue(production) {
     if (production.isEpsilon()) {
-      return '__loc = None;';
+      return '__loc = None';
     }
     return CodeUnit.createLocationPrologue(production);
   },

--- a/src/plugins/python/templates/tokenizer.template.py
+++ b/src/plugins/python/templates/tokenizer.template.py
@@ -171,7 +171,7 @@ class Tokenizer(object):
     def throw_unexpected_token(self, symbol, line, column):
         line_source = self._string.split('\n')[line - 1]
 
-        pad = ' ' * column;
+        pad = ' ' * column
         line_data = '\n\n' + line_source + '\n' + pad + '^\n'
 
         raise Exception(


### PR DESCRIPTION
This contribution is made after ["Building an Interpreter from scratch"](https://www.udemy.com/share/102HTk3@ieQfJxeXbAGlI_ltW7_EjFd37ukiS0zbfAKXHV-8yQgkhn1uU4VijBgZZ8z3bayiwA==/) course. Generated parser on python contains semicolons that have to be removed manually every time you regenerate it.

I have tested it on course materials, working out of the box now.
`npm test` passes (except rust):
![tests](https://user-images.githubusercontent.com/47736196/195914991-32597630-c578-4c26-b641-2113d4f07dac.png)

