### PR TITLE
feat: generate raw strings for python regex

### DIFF
--- a/src/plugins/python/py-parser-generator-trait.js
+++ b/src/plugins/python/py-parser-generator-trait.js
@@ -103,7 +103,7 @@ const PythonParserGeneratorTrait = {
         flags = '';
       }
 
-      return `['${flags}${lexRule.getRawMatcher()}', ` +
+      return `[r'${flags}${lexRule.getRawMatcher()}', ` +
         `_lex_rule${this._lexHandlers.length}]`;
     });
 


### PR DESCRIPTION
This PR addresses [Issue #129](https://github.com/DmitrySoshnikov/syntax/issues/129). Repo tests failed locally immediately on the pull, I suspect due to some configuration mistake on my end after the initial clone. 

I have tested locally and verified the following:

a) When generating a python parser, regexes for the lex_rules are now generated as raw strings (`r'\"a_regex\"'`)
b) These raw strings, when used in a consuming python program, properly parse tokens without further modification of the generated parser 