### PR TITLE
fix PHP templates

### DIFF
--- a/src/plugins/php/templates/ll.template.php
+++ b/src/plugins/php/templates/ll.template.php
@@ -60,15 +60,14 @@ class yyparse {
   }
 
   public static function parse($string) {
-    if (self::$on_parse_begin) {
-      $on_parse_begin = self::$on_parse_begin;
-      $on_parse_begin($string);
+    if (is_callable(self::$on_parse_begin)) {
+      call_user_func(self::$on_parse_begin, $string);
     }
 
     $tokenizer = self::getTokenizer();
 
     if (!$tokenizer) {
-      throw new \Exception(`Tokenizer instance wasn't specified.`);
+      throw new \Exception('Tokenizer instance wasn\'t specified.');
     }
 
     $tokenizer->initString($string);

--- a/src/plugins/php/templates/lr.template.php
+++ b/src/plugins/php/templates/lr.template.php
@@ -131,7 +131,7 @@ class yyparse {
   private static function yyloc($start, $end) {
     // Epsilon doesn't produce location.
     if (!$start || !$end) {
-      return !$start ? $end : $static;
+      return !$start ? $end : $start;
     }
 
     return array(
@@ -165,15 +165,14 @@ class yyparse {
   }
 
   public static function parse($string) {
-    if (self::$on_parse_begin) {
-      $on_parse_begin = self::$on_parse_begin;
-      $on_parse_begin($string);
+    if (is_callable(self::$on_parse_begin)) {
+      call_user_func(self::$on_parse_begin, $string);
     }
 
     $tokenizer = self::getTokenizer();
 
     if (!$tokenizer) {
-      throw new SyntaxException(`Tokenizer is not provided.`);
+      throw new SyntaxException('Tokenizer is not provided.');
     }
 
     $tokenizer->initString($string);
@@ -267,7 +266,7 @@ class yyparse {
           self::$yyleng = $shifted_token ? strlen($shifted_token['value']) : null;
 
           forward_static_call_array(
-            array('self', $production[2]),
+            array(get_class(), $production[2]),
             $location_args !== null
               ? array_merge($semantic_value_args, $location_args)
               : $semantic_value_args
@@ -302,9 +301,8 @@ class yyparse {
           ? $parsed['semanticValue']
           : true;
 
-        if (self::$on_parse_end) {
-          $on_parse_end = self::$on_parse_end;
-          $on_parse_end($parsed_value);
+        if (is_callable(self::$on_parse_end)) {
+          call_user_func(self::$on_parse_end, $parsed_value);
         }
 
         return $parsed_value;

--- a/src/plugins/php/templates/tokenizer.template.php
+++ b/src/plugins/php/templates/tokenizer.template.php
@@ -76,7 +76,7 @@ class Tokenizer {
   }
 
   public function begin($state) {
-    $this->pushState(state);
+    $this->pushState($state);
   }
 
   public function popState() {


### PR DESCRIPTION
This PR fixes some errors in PHP templates.

### On `src/plugins/php/templates/tokenizer.template.php`

- Adds a missing `$` to the `$state` variable on method `Tokenizer::begin()`

### On `src/plugins/php/templates/ll.template.php`

- Uses `call_user_func()` to call `static::$on_parse_begin` hook, instead of assigning it to a temporary variable
- Also changes the check to verify if `static::$on_parse_begin` is a callable using `is_callable` (available since PHP 5.3)
- Changes the exception message thrown on line 71 (of the original code) to use single quotes instead of backticks. Backticks are used in PHP to execute shell code, and can be disabled through a `php.ini` directive

### On `src/plugins/php/templates/lr.template.php`

- Fixes line 134 to return `$start` instead of a non-existent `$static` variable, within the check to see if either `$start` or `$end` are valid values
- Uses `call_user_func()` to call `static::$on_parse_begin` hook, instead of assigning it to a temporary variable
- Also changes the check to verify if `static::$on_parse_begin` is a callable using `is_callable` (available since PHP 4.0.6)
- Changes the exception message thrown on line 176 (of the original code) to use single quotes instead of backticks. Backticks are used in PHP to execute shell code, and can be disabled through a `php.ini` directive
- Uses `get_class()` instead of the `'self'` string when calling `forward_static_call_array()` on line 270 (of original code). Using the string `'self'` and `'static'` on callable array syntax is deprecated as of PHP 8.2, and generates a warning. `get_class()` is available since PHP 4
- Uses `call_user_func()` to call `static::$on_parse_end` hook, instead of assigning it to a temporary variable
- Also changes the check to verify if `static::$on_parse_end` is a callable using `is_callable` (available since PHP 4.0.6)


### Notes: 

I wasn't sure which PHP version the parser generator targets, so I tried to keep the most backwards-compatible approach possible.

From the built-in functions used, `forward_static_call()` was introduced in PHP 5.3, that is why I replaced `array('self', $production[2])`, by `array(get_class(), $production[2])` - to avoid a deprecation warning on PHP 8.2 - instead of replacing it by `array(self::class, $production[2])`, as `::class` notation was introduced in PHP 5.5.

I had to skip git hooks when committing and pushing, as tests were failing. But they were already failing when I ran `npm ci` to install dependencies, and none of the failures were related to the PHP template changes I made.

I can try fixing those errors, if you'd like me to, but I prefer to do it on a separate PR, as none of them are related to the changes on this PR.


### References: 

- https://www.php.net/manual/en/language.operators.execution.php
- https://www.php.net/manual/en/function.is-callable.php
- https://www.php.net/manual/en/function.get-class.php
- https://www.php.net/manual/en/function.forward-static-call-array.php
- https://wiki.php.net/rfc/deprecate_partially_supported_callables


### Epilogue

By the way, thanks for this tool. =) 

I discovered it when watching your "Building a Parser from Scratch" course, and was very surprised to discover it supported PHP.

Greetings from Brazil.
