### PR TITLE
Stop using runtime C++ exceptions

### DIFF
--- a/src/plugins/cpp/templates/lr.template.h
+++ b/src/plugins/cpp/templates/lr.template.h
@@ -250,7 +250,7 @@ class {{{PARSER_CLASS_NAME}}} {
     if (token->type == TokenType::__EOF && !tokenizer.hasMoreTokens()) {
       std::string errMsg = "Unexpected end of input.\n";
       std::cerr << errMsg;
-      throw std::runtime_error(errMsg.c_str());
+      std::exit(EXIT_FAILURE);
     }
     tokenizer.throwUnexpectedToken(token->value, token->startLine,
                                    token->startColumn);

--- a/src/plugins/cpp/templates/tokenizer.template.h
+++ b/src/plugins/cpp/templates/tokenizer.template.h
@@ -204,7 +204,7 @@ class Tokenizer {
            << ":" << column << "\n\n";
 
     std::cerr << errMsg.str();
-    throw new std::runtime_error(errMsg.str().c_str());
+    std::exit(1);
   }
 
   /**


### PR DESCRIPTION
## Replace ```throw``` by ```std::exit```

As of LLVM 18, llvm-config --cxxflags contains -fno-exceptions, general standards are also moving out runtime exceptions in C++ as much as possible c.f. [stackoverflow discussion](https://stackoverflow.com/questions/4506369/when-and-how-should-i-use-exception-handling).

I can't run test since the dev is broken because of transition from babel 6 to 7 (I don't know enough about babel to update everything to babel 7) and there is no version nor instruction specifying the required npm and node.