### PR TITLE
Bug fix in LL1 table generator

### DIFF
--- a/src/ll/__tests__/grammar1.bnf
+++ b/src/ll/__tests__/grammar1.bnf
@@ -1,0 +1,11 @@
+// https://github.com/DmitrySoshnikov/syntax/issues/151
+
+%%
+
+S
+  : A
+  ;
+A
+  : 'a'
+  | /* empty */
+  ;

--- a/src/ll/__tests__/ll-parsing-table-test.js
+++ b/src/ll/__tests__/ll-parsing-table-test.js
@@ -1,0 +1,40 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2015-present Dmitry Soshnikov <dmitry.soshnikov@gmail.com>
+ */
+
+import Grammar from '../../grammar/grammar';
+import {MODES as GRAMMAR_MODE} from '../../grammar/grammar-mode';
+import LLParsingTable from '../ll-parsing-table';
+import LLParser from '../ll-parser';
+
+describe('ll-parsing-table', () => {
+  it('ll1-grammar-1', () => {
+    const grammarFile = __dirname + '/grammar1.bnf';
+    const expectedTable = {
+      S: {
+        "'a'": '1',
+        $: '1',
+      },
+      A: {
+        "'a'": '2',
+        $: '3',
+      },
+    };
+
+    const grammarBySLR = Grammar.fromGrammarFile(grammarFile, {
+      mode: GRAMMAR_MODE.LL1,
+    });
+    expect(new LLParsingTable({grammar: grammarBySLR}).get()).toEqual(
+      expectedTable
+    );
+    expect(new LLParser({grammar: grammarBySLR}).parse('a')).toEqual({
+      status: 'accept',
+      semanticValue: true,
+    });
+    expect(new LLParser({grammar: grammarBySLR}).parse('')).toEqual({
+      status: 'accept',
+      semanticValue: true,
+    });
+  });
+});

--- a/src/ll/ll-parsing-table.js
+++ b/src/ll/ll-parsing-table.js
@@ -182,7 +182,7 @@ export default class LLParsingTable {
       // If First(RHS) has an epsilon terminal it means
       // that we must check also under the Follow(LHS) column.
       // (because this production can be eliminated by epsilon).
-      if (set[EPSILON]) {
+      if (set.hasOwnProperty(EPSILON)) {
         // Compute (First(RHS) - {ε}) + Follow(LHS)
         delete set[EPSILON];
         set = Object.assign({}, set, this._setsGenerator.followOf(lhs));


### PR DESCRIPTION
In the example exposed in https://github.com/DmitrySoshnikov/syntax/issues/151:

```
%%

S -> A;
A -> "a" | ;
```

```
Parsing mode: LL(1).

Grammar:

    1. S -> A
    2. A -> 'a'
    3.    | ε
```
we get the wrong LL1 Parsing Table:

```
LL(1) parsing table:

┌───┬─────┬───┐
│   │ "a" │ $ │
├───┼─────┼───┤
│ S │ 1   │   │
├───┼─────┼───┤
│ A │ 2   │ 3 │
└───┴─────┴───┘
```

The problem is in the condition that checks the existence of ε, because a production may have other terminals besides ε.
In our case, the First(A) set equals to `"a", ε`. When we fill the table we should consider `"a"` and replace `ε` with the Follow(S) set.

After this patch we get the expected result:

```
LL(1) parsing table:

┌───┬─────┬───┐
│   │ 'a' │ $ │
├───┼─────┼───┤
│ S │ 1   │ 1 │
├───┼─────┼───┤
│ A │ 2   │ 3 │
└───┴─────┴───┘
```

Should fix #151